### PR TITLE
Add homepage with participants list

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,8 @@
+---
+layout: home
+permalink: /
+description: Enjoy HacktoberFest 2019 together with friends and mentors at Takeaweay.com!
+title: Takeaweay.com 2019 HacktoberFest Event
+---
+
+# Takeaweay.com 2019 HacktoberFest Event

--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,8 @@
+---
+data_dir: _participants
+defaults:
+  -
+    scope:
+      path: "" # empty string for all files
+    values:
+      layout: "default"

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -22,6 +22,5 @@
   
   {{ content }}
 
-  <script src="{{ site.baseurl }}/assets/main.js"></script>
 </body>
 </html>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,0 +1,27 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>{{ page.title }}</title>
+  <!-- @TODO: 
+    <link rel="shortcut icon" href="./favicon.ico" type="image/x-icon" />
+    <link rel="manifest" href="site.webmanifest">
+    <link rel="apple-touch-icon" href="icon.png">
+  -->
+  <meta name="description" content="{{ page.description }}">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="theme-color" content="#ff8000">
+
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bulma/0.7.5/css/bulma.min.css" integrity="sha256-vK3UTo/8wHbaUn+dTQD0X6dzidqc5l7gczvH+Bnowwk=" crossorigin="anonymous" />
+  <!-- @TODO:
+    <link rel="stylesheet" href="{{ site.baseurl }}/assets/main.css" media="all">
+  -->
+</head>
+
+<body>
+  
+  {{ content }}
+
+  <script src="{{ site.baseurl }}/assets/main.js"></script>
+</body>
+</html>

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -1,0 +1,46 @@
+---
+layout: default
+---
+
+<section class="hero is-large">
+  <div class="hero-body">
+    <div class="container">
+      <h1 class="title">
+        Takeaway.com
+      </h1>
+      <h2 class="subtitle">
+        HacktoberFest 2019
+      </h2>
+    </div>
+  </div>
+</section>
+
+<article class="section main-content">
+  <div class="container">
+    {{ content }}
+  </div>
+</article>
+
+<section class="section participants">
+  <h2>Participants</h2>
+  <div class="container">
+    {% for participant_hash in site.data.participants %}
+      {% assign participant = participant_hash[1] %}
+      <pre>{{ participant }}</pre>
+      {% comment %}
+        <!-- @TODO: Add participant details -->
+        {% for person in participant %}
+          <li>{{ person.name }}</li>
+          <li>{{ person.website }}</li>
+          <li>{{ person.github }}</li>
+          <li>{{ person.level }}</li>
+          <li>{{ person.organisation.name }}</li>
+          <li>{{ person.organisation.website }}</li>
+          <ol>{{ person.repos }}</ol>
+          <ul>{{ person.social }}</ul>
+          <p>{{ person.comment | newline_to_br }}</p>
+        {% endfor %}
+      {% endcomment %}
+    {% endfor %}
+  </div>
+</section>

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -22,25 +22,67 @@ layout: default
 </article>
 
 <section class="section participants">
-  <h2>Participants</h2>
-  <div class="container">
-    {% for participant_hash in site.data.participants %}
-      {% assign participant = participant_hash[1] %}
-      <pre>{{ participant }}</pre>
-      {% comment %}
-        <!-- @TODO: Add participant details -->
-        {% for person in participant %}
-          <li>{{ person.name }}</li>
-          <li>{{ person.website }}</li>
-          <li>{{ person.github }}</li>
-          <li>{{ person.level }}</li>
-          <li>{{ person.organisation.name }}</li>
-          <li>{{ person.organisation.website }}</li>
-          <ol>{{ person.repos }}</ol>
-          <ul>{{ person.social }}</ul>
-          <p>{{ person.comment | newline_to_br }}</p>
-        {% endfor %}
-      {% endcomment %}
+  <h2 class="title">Participants</h2>
+  <div class="columns participant-container">
+    {% for participant_hash in site.data.2019 %}
+      {% assign person = participant_hash[1] %}
+        <ul class="box column is-one-quarter participant">
+          <li class="is-pulled-left participant__name">
+            {% if person.website %}
+              <a class="participant__link" href="{{ person.website }}">{{ person.name }}</a>
+            {% else %}
+              {{ person.name }}
+            {% endif %}
+          </li>
+          <li class="is-pulled-right participant__github"><a href="https://github.com/{{ person.github }}">@{{ person.github }}</a></li>
+          <li class="has-text-centered participant__level">{{ person.level }}</li>
+
+          {% if person.organisation.name %}
+            <li class="participant__organisation">
+              {% if person.organisation.website %}
+                <a class="participant__organisation-link" href="{{ person.website }}">{{ person.organisation.name }}</a>
+              {% else %}
+                {{ person.organisation.name }}
+              {% endif %}
+            </li>
+          {% endif %}
+
+          {% if person.repos %}
+            <li class="participant__repos">
+              <ol class="participant__repos list">
+              {% for repo in person.repos %}
+                <li class="list-item">
+                  {% if repo contains "/" %}
+                  <a href="https://github.com/{{ repo }}">{{ repo }}</a>
+                  {% else %}
+                    {{ repo }}
+                  {% endif %}
+                </li>
+              {% endfor %}
+              </ol>
+            </li>
+          {% endif %}
+
+          {% if person.comment %}
+            <li class="participant__comment">{{ person.comment | newline_to_br }}</li>
+          {% endif %}
+
+          {% if person.social %}
+            <li class="participant__social-container">
+              <ul class="participant__social list">
+                {% for social in person.social %}
+                <li class="list-item participant__social--{{ social[0] }}">
+                  <span class="participant__social-name">
+                    <a class="participant__social-link" href="{{ social[1] }}">
+                    {{ social[0] | replace: "_", " " }}
+                    </a>
+                  </span>
+                </li>
+                {% endfor %}
+              </ul>
+            </li>
+          {% endif %}
+        </ul>
     {% endfor %}
   </div>
 </section>

--- a/_participants/2019/ben.peachey.yml
+++ b/_participants/2019/ben.peachey.yml
@@ -19,7 +19,7 @@ github: potherca
 
 # ------------------------------------------------------------------------------
 # What level of open-source contribution skillz do you have?
-# beginner / intermediate / advenced
+# beginner / intermediate / advanced
 level: advanced
 
 # ==============================================================================

--- a/_participants/2019/ben.peachey.yml
+++ b/_participants/2019/ben.peachey.yml
@@ -1,0 +1,61 @@
+--- 
+# ==============================================================================
+# This file serves as an example so you can add your own information to the list
+# of people who participated to the Takeaway 2019 HakctoberFest Event!
+#
+# If you are not sure if your YAML is correct, check it here: http://www.yamllint.com/
+
+# ==============================================================================
+# The following three fields (name, github, level) are required, everything else
+# is optional.
+
+# ------------------------------------------------------------------------------
+# How do you want people to address you? (does not have to be your _real_ name)
+name: Ben Peachey
+
+# ------------------------------------------------------------------------------
+# What are you called on Github? (So we can check this is your Merge Request)
+github: potherca
+
+# ------------------------------------------------------------------------------
+# What level of open-source contribution skillz do you have?
+# beginner / intermediate / advenced
+level: advanced
+
+# ==============================================================================
+# The fields below are all optional. Do you want to share more about yourself?
+
+# ------------------------------------------------------------------------------
+# Is there a website you want to link to?
+website: https://pother.ca/
+
+# ------------------------------------------------------------------------------
+# What projects do you plan on contributing to? (Or have you already contributed to?)
+repos:
+ - takeaway/hacktoberfest
+ - "?"
+ - "?"
+ - "?"
+ - "?"
+
+# ------------------------------------------------------------------------------
+# Where else can you be found? The key names can be whatever you like.
+# You can use letter and numbers, underscores can be used as spaces.
+social:
+  LinkedIn: https://www.linkedin.com/in/benpeachey/
+  Twitter: https://twitter.com/potherca
+  StackOverflow: https://stackoverflow.com/users/153049/potherca
+  Regex_Crossword: https://regexcrossword.com/profile/26744
+
+# Are you affilated to a company, place of education, or other organisation?
+organisation: 
+  name: Takeaway.com
+  website: https://takeaway.com/
+
+# Is there anything you want to share with the world at large?
+comment: >
+  I am one of the co-organisers of the event and one of the mentors that help out
+  during the event by giving mini-workshops and explaining things people might
+  struggle with.
+  
+  I would like to thank everyone for coming!

--- a/notes.md
+++ b/notes.md
@@ -1,0 +1,60 @@
+## Values
+
+- Everyone is welcome!
+- Quantity is fun, quality is key!
+- Short-term actions, long-term impact!
+
+## Quality standards
+
+In line with Hacktoberfest value #2 (Quantity is fun, quality is key), here are examples of the PRs that we consider to be low-quality contributions (which we discourage).
+
+- PRs that are automated (e.g. scripted opening PRs to remove whitespace/optimize images)
+- PRs that are disruptive (e.g. taking someone else's branch/commits and making a PR)
+- PRs that are regarded by a project maintainer as a hindrance vs. helping
+- Something that's clearly an attempt to simply +1 your PR count for October
+- Last but not least, one PR to fix a typo is fine. 5 PRs to remove a stray whitespace... not.
+
+- Spammy PRs can be labeled as “invalid.”
+- There’s a seven-day review window for PRs.
+- Bad repositories will be excluded.
+  (see https://github.com/hacktoberfest-team?tab=overview&from=2019-09-01&to=2019-09-30)
+
+## Find a repo
+
+`@TODO: Sort into "beginner", "inermediate" and "advanced"`
+
+- https://www.firsttimersonly.com
+- http://yourfirstpr.github.io/
+
+- https://up-for-grabs.net/
+- http://issuehub.io/
+- https://gauger.io/contrib/
+- https://www.codetriage.com
+
+- http://www.pullrequestroulette.com
+- https://github.com/topics/hacktoberfest
+
+## Check peoples progress
+
+- https://github.com/jenkoian/hacktoberfest-checker
+
+## Guides
+
+- https://www.digitalocean.com/community/tutorial_series/an-introduction-to-open-source
+- https://opensource.guide/how-to-contribute/
+
+## Awesome lists
+
+- https://github.com/mungell/awesome-for-beginners
+- https://github.com/mattjegan/awesome-hacktoberfest
+- https://github.com/OtacilioN/awesome-hacktoberfest-2019
+
+## Swag lists
+
+- https://devswag.io/?tags=hacktoberfest
+- https://dev.to/m1guelpf/hacktoberfest-2019-swag-list-3ajg
+- https://hacktoberfestswaglist.com (https://github.com/crweiner/hacktoberfest-swag-list)
+
+## Hacktober history
+
+- [Google Images for past Hacktoberfests](https://www.google.com/search?rlz=1CAEAQE_enNL697NL697&biw=1366&bih=609&tbm=isch&sxsrf=ACYBGNSaiWqB3qR4moQe64LGUSPUXxMi7g%3A1571254854616&sa=1&ei=RnKnXa-WJYPfwQL2gqiICA&q=site%3Ablog.digitalocean.com+"hacktoberfest"&oq=site%3Ablog.digitalocean.com+"hacktoberfest"&gs_l=img.3...1589.2480..2763...0.0..0.61.214.4......0....1..gws-wiz-img.o6yPzFeOYaU&ved=0ahUKEwiv0de7xKHlAhWDb1AKHXYBCoEQ4dUDCAc&uact=5)


### PR DESCRIPTION
This MR adds Jekyll files that enable specific YAML files to be displayed on the homepage.
This makes it possible for participants to add a file with their info which will automatically display them as participant at https://takeaway.technology/hacktoberfest/
 
The result can be seen here: https://contrib.pother.ca/hacktoberfest/

Closes #2